### PR TITLE
onError callback in options for android

### DIFF
--- a/speech-recognition.android.ts
+++ b/speech-recognition.android.ts
@@ -101,6 +101,7 @@ export class SpeechRecognition implements SpeechRecognitionApi {
               onError(error: number) {
                 console.log("Error: " + error);
                 reject("Error code: " + error);
+                options.onError(error);
               },
 
               /**

--- a/speech-recognition.common.ts
+++ b/speech-recognition.common.ts
@@ -21,6 +21,12 @@ export interface SpeechRecognitionOptions {
    * @param transcription
    */
   onResult: (transcription: SpeechRecognitionTranscription) => void;
+
+  /**
+   * The callback function invoked when an error occurs during speech recognition
+   * @param error
+   */
+  onError?: (error: number) => void;
 }
 
 export interface SpeechRecognitionApi {

--- a/speech-recognition.common.ts
+++ b/speech-recognition.common.ts
@@ -24,7 +24,7 @@ export interface SpeechRecognitionOptions {
 
   /**
    * The callback function invoked when an error occurs during speech recognition
-   * @param error
+   * @param error error code constants from https://developer.android.com/reference/android/speech/SpeechRecognizer
    */
   onError?: (error: number) => void;
 }


### PR DESCRIPTION
Added an optional onError callback to the options object. It is called on errors in Android and provides the error code from the SpeechRecognizer of Android. A link to the error codes is provided in the doc comment.
I don't know if there's a place it should also be called on iOS, as I'm only using this on Android.

I have tested that it works and I use it to restart listening when nothing is recognized or recognition times out (error codes 6 ERROR_SPEECH_TIMEOUT and 7 ERROR_NO_MATCH).